### PR TITLE
refactor(pty): 重构shell检测与环境配置逻辑，抽离通用工具模块

### DIFF
--- a/tauri-plugin-pty/src/commands/shell.rs
+++ b/tauri-plugin-pty/src/commands/shell.rs
@@ -1,4 +1,4 @@
-use portable_pty::{CommandBuilder, NativePtySystem, PtySize, PtySystem};
+use portable_pty::{NativePtySystem, PtySize, PtySystem};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use std::io::{Read, Write};
@@ -13,6 +13,7 @@ use tauri::{
 use crate::{
   error::{PtyError, PtyResult},
   pty_manager::{PtyManager, ShellInstance},
+  utils::{build_shell_command, detect_shell},
 };
 
 type ShellId = String;
@@ -39,16 +40,6 @@ impl IpcResponse for PtyIpcEvent {
         json!({"type": "Exit", "code": code}).to_string(),
       )),
     }
-  }
-}
-
-fn detect_shell() -> String {
-  if cfg!(target_os = "windows") {
-    "powershell.exe".to_string()
-  } else if cfg!(target_os = "macos") {
-    std::env::var("SHELL").unwrap_or_else(|_| "zsh".to_string())
-  } else {
-    std::env::var("SHELL").unwrap_or_else(|_| "bash".to_string())
   }
 }
 
@@ -79,7 +70,7 @@ pub async fn shell_open<R: Runtime>(
     .map_err(|e| PtyError::new(e.to_string()))?;
 
   let shell_cmd = shell.unwrap_or_else(detect_shell);
-  let cmd = CommandBuilder::new(&shell_cmd);
+  let cmd = build_shell_command(&shell_cmd);
   let mut child = pair
     .slave
     .spawn_command(cmd)

--- a/tauri-plugin-pty/src/lib.rs
+++ b/tauri-plugin-pty/src/lib.rs
@@ -1,6 +1,7 @@
 pub(crate) mod commands;
 pub(crate) mod error;
 pub(crate) mod pty_manager;
+pub(crate) mod utils;
 
 use pty_manager::PtyManager;
 use tauri::{

--- a/tauri-plugin-pty/src/utils/mod.rs
+++ b/tauri-plugin-pty/src/utils/mod.rs
@@ -1,0 +1,39 @@
+use portable_pty::CommandBuilder;
+
+mod platform;
+
+pub(crate) fn detect_shell() -> String {
+  platform::detect_shell()
+}
+
+pub(crate) fn build_shell_command(shell_cmd: &str) -> CommandBuilder {
+  let mut cmd = CommandBuilder::new(shell_cmd);
+  platform::configure_shell_env(&mut cmd, shell_cmd);
+  platform::configure_shell_args(&mut cmd, shell_cmd);
+  cmd
+}
+
+fn non_empty_env(key: &str) -> Option<String> {
+  std::env::var(key)
+    .ok()
+    .filter(|value| !value.trim().is_empty())
+}
+
+fn env_or_default(key: &str, default_value: &str) -> String {
+  non_empty_env(key).unwrap_or_else(|| default_value.to_string())
+}
+
+fn configure_common_terminal_env(cmd: &mut CommandBuilder, shell_cmd: &str, path: String) {
+  cmd.env("SHELL", shell_cmd);
+  cmd.env("TERM", env_or_default("TERM", "xterm-256color"));
+  cmd.env("COLORTERM", env_or_default("COLORTERM", "truecolor"));
+  cmd.env("PATH", path);
+
+  if let Some(lang) = non_empty_env("LANG") {
+    cmd.env("LANG", lang);
+  }
+
+  if let Some(lc_all) = non_empty_env("LC_ALL") {
+    cmd.env("LC_ALL", lc_all);
+  }
+}

--- a/tauri-plugin-pty/src/utils/platform/macos.rs
+++ b/tauri-plugin-pty/src/utils/platform/macos.rs
@@ -1,0 +1,62 @@
+use std::path::Path;
+use std::process::Command as ProcessCommand;
+
+use portable_pty::CommandBuilder;
+
+use crate::utils::{configure_common_terminal_env, non_empty_env};
+
+pub(super) fn detect_shell() -> String {
+  non_empty_env("SHELL").unwrap_or_else(|| "/bin/zsh".to_string())
+}
+
+pub(super) fn configure_shell_env(cmd: &mut CommandBuilder, shell_cmd: &str) {
+  configure_common_terminal_env(cmd, shell_cmd, resolve_path());
+}
+
+pub(super) fn configure_shell_args(cmd: &mut CommandBuilder, shell_cmd: &str) {
+  let shell_name = shell_name(shell_cmd);
+  if matches!(
+    shell_name.as_str(),
+    "bash" | "zsh" | "fish" | "sh" | "csh" | "tcsh"
+  ) {
+    cmd.arg("-l");
+  }
+}
+
+fn resolve_path() -> String {
+  let current_path = std::env::var("PATH").unwrap_or_default();
+  if !should_use_fallback_path(&current_path) {
+    return current_path;
+  }
+
+  path_helper()
+    .unwrap_or_else(|| "/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin".to_string())
+}
+
+fn should_use_fallback_path(path: &str) -> bool {
+  path.trim().is_empty() || path == "/usr/bin:/bin:/usr/sbin:/sbin"
+}
+
+fn path_helper() -> Option<String> {
+  let output = ProcessCommand::new("/usr/libexec/path_helper")
+    .arg("-s")
+    .output()
+    .ok()?;
+  if !output.status.success() {
+    return None;
+  }
+
+  let stdout = String::from_utf8(output.stdout).ok()?;
+  let start = stdout.find("PATH=\"")? + "PATH=\"".len();
+  let rest = stdout.get(start..)?;
+  let end = rest.find("\";")?;
+  Some(rest[..end].to_string()).filter(|path| !path.trim().is_empty())
+}
+
+fn shell_name(shell_cmd: &str) -> String {
+  Path::new(shell_cmd)
+    .file_name()
+    .and_then(|name| name.to_str())
+    .unwrap_or_default()
+    .to_string()
+}

--- a/tauri-plugin-pty/src/utils/platform/mod.rs
+++ b/tauri-plugin-pty/src/utils/platform/mod.rs
@@ -1,0 +1,59 @@
+#[cfg(target_os = "macos")]
+mod macos;
+#[cfg(all(unix, not(target_os = "macos")))]
+mod unix;
+#[cfg(windows)]
+mod windows;
+
+use portable_pty::CommandBuilder;
+
+pub(super) fn detect_shell() -> String {
+  #[cfg(target_os = "macos")]
+  {
+    macos::detect_shell()
+  }
+
+  #[cfg(all(unix, not(target_os = "macos")))]
+  {
+    unix::detect_shell()
+  }
+
+  #[cfg(windows)]
+  {
+    windows::detect_shell()
+  }
+}
+
+pub(super) fn configure_shell_env(cmd: &mut CommandBuilder, shell_cmd: &str) {
+  #[cfg(target_os = "macos")]
+  {
+    macos::configure_shell_env(cmd, shell_cmd);
+  }
+
+  #[cfg(all(unix, not(target_os = "macos")))]
+  {
+    unix::configure_shell_env(cmd, shell_cmd);
+  }
+
+  #[cfg(windows)]
+  {
+    windows::configure_shell_env(cmd, shell_cmd);
+  }
+}
+
+pub(super) fn configure_shell_args(cmd: &mut CommandBuilder, shell_cmd: &str) {
+  #[cfg(target_os = "macos")]
+  {
+    macos::configure_shell_args(cmd, shell_cmd);
+  }
+
+  #[cfg(all(unix, not(target_os = "macos")))]
+  {
+    unix::configure_shell_args(cmd, shell_cmd);
+  }
+
+  #[cfg(windows)]
+  {
+    windows::configure_shell_args(cmd, shell_cmd);
+  }
+}

--- a/tauri-plugin-pty/src/utils/platform/unix.rs
+++ b/tauri-plugin-pty/src/utils/platform/unix.rs
@@ -1,0 +1,37 @@
+use std::path::Path;
+
+use portable_pty::CommandBuilder;
+
+use crate::utils::{configure_common_terminal_env, non_empty_env};
+
+pub(super) fn detect_shell() -> String {
+  non_empty_env("SHELL").unwrap_or_else(|| "/bin/bash".to_string())
+}
+
+pub(super) fn configure_shell_env(cmd: &mut CommandBuilder, shell_cmd: &str) {
+  configure_common_terminal_env(cmd, shell_cmd, resolve_path());
+}
+
+pub(super) fn configure_shell_args(cmd: &mut CommandBuilder, shell_cmd: &str) {
+  let shell_name = shell_name(shell_cmd);
+  if matches!(shell_name.as_str(), "fish") {
+    cmd.arg("--interactive");
+  }
+}
+
+fn resolve_path() -> String {
+  let current_path = std::env::var("PATH").unwrap_or_default();
+  if !current_path.trim().is_empty() {
+    return current_path;
+  }
+
+  "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin".to_string()
+}
+
+fn shell_name(shell_cmd: &str) -> String {
+  Path::new(shell_cmd)
+    .file_name()
+    .and_then(|name| name.to_str())
+    .unwrap_or_default()
+    .to_string()
+}

--- a/tauri-plugin-pty/src/utils/platform/windows.rs
+++ b/tauri-plugin-pty/src/utils/platform/windows.rs
@@ -1,0 +1,54 @@
+use std::path::Path;
+
+use portable_pty::CommandBuilder;
+
+use crate::utils::{configure_common_terminal_env, env_or_default, non_empty_env};
+
+pub(super) fn detect_shell() -> String {
+  non_empty_env("SHELL").unwrap_or_else(|| "powershell.exe".to_string())
+}
+
+pub(super) fn configure_shell_env(cmd: &mut CommandBuilder, shell_cmd: &str) {
+  configure_common_terminal_env(cmd, shell_cmd, resolve_path());
+  cmd.env(
+    "PATHEXT",
+    env_or_default(
+      "PATHEXT",
+      ".COM;.EXE;.BAT;.CMD;.VBS;.VBE;.JS;.JSE;.WSF;.WSH;.MSC",
+    ),
+  );
+}
+
+pub(super) fn configure_shell_args(cmd: &mut CommandBuilder, shell_cmd: &str) {
+  let shell_name = shell_name(shell_cmd);
+  if matches!(
+    shell_name.as_str(),
+    "powershell.exe" | "pwsh.exe" | "powershell" | "pwsh"
+  ) {
+    cmd.arg("-NoLogo");
+  }
+}
+
+fn resolve_path() -> String {
+  let current_path = std::env::var("PATH").unwrap_or_default();
+  if !current_path.trim().is_empty() {
+    return current_path;
+  }
+
+  let system_root = non_empty_env("SystemRoot").unwrap_or_else(|| "C:\\Windows".to_string());
+  [
+    format!("{system_root}\\System32"),
+    system_root.clone(),
+    format!("{system_root}\\System32\\Wbem"),
+    format!("{system_root}\\System32\\WindowsPowerShell\\v1.0"),
+  ]
+  .join(";")
+}
+
+fn shell_name(shell_cmd: &str) -> String {
+  Path::new(shell_cmd)
+    .file_name()
+    .and_then(|name| name.to_str())
+    .unwrap_or_default()
+    .to_ascii_lowercase()
+}


### PR DESCRIPTION
将跨平台的shell检测、终端环境配置逻辑抽离到utils模块，统一各平台实现，移除重复代码，提升代码可维护性